### PR TITLE
Changes to runAfterInteractions and additional exposed props

### DIFF
--- a/lib/index.android.js
+++ b/lib/index.android.js
@@ -17,10 +17,16 @@ import styles from './style';
 export default class VideoRecorder extends Component {
   static propTypes = {
     isOpen: PropTypes.bool,
+    runAfterInteractions: PropTypes.bool,
+    buttonCloseStyle: PropTypes.shape({}),
+    durationTextStyle: PropTypes.shape({}),
   }
 
   static defaultProps = {
     isOpen: false,
+    runAfterInteractions: true,
+    buttonCloseStyle: styles.buttonClose,
+    durationTextStyle: styles.durationText,
   }
 
   constructor(...props) {
@@ -35,9 +41,12 @@ export default class VideoRecorder extends Component {
   }
 
   componentDidMount() {
-    InteractionManager.runAfterInteractions(() => {
-      this.setState({ loading: false });
-    });
+    const doPostMount = () => this.setState({ loading: false });
+    if (this.props.runAfterInteractions) {
+      InteractionManager.runAfterInteractions(doPostMount);
+    } else {
+      doPostMount();
+    }
   }
 
   onSave = () => {
@@ -61,7 +70,7 @@ export default class VideoRecorder extends Component {
   }
 
   startCapture = () => {
-    InteractionManager.runAfterInteractions(() => {
+    const shouldStartCapture = () => {
       this.camera.capture()
       .then((data) => {
         console.log('video capture', data);
@@ -79,17 +88,27 @@ export default class VideoRecorder extends Component {
           time: 0,
         });
       });
-    });
+    };
+    if (this.props.runAfterInteractions) {
+      InteractionManager.runAfterInteractions(shouldStartCapture);
+    } else {
+      shouldStartCapture();
+    }
   }
 
   stopCapture = () => {
-    InteractionManager.runAfterInteractions(() => {
+    const shouldStopCapture = () => {
       this.stopTimer();
       this.camera.stopCapture();
       this.setState({
         isRecording: false,
       });
-    });
+    };
+    if (this.props.runAfterInteractions) {
+      InteractionManager.runAfterInteractions(shouldStopCapture);
+    } else {
+      shouldStopCapture();
+    }
   }
 
   startTimer = () => {
@@ -112,7 +131,7 @@ export default class VideoRecorder extends Component {
       <View>
         {
           (recorded || isRecording) &&
-          <Text style={styles.durationText}>
+          <Text style={this.props.durationTextStyle}>
             <Text style={styles.dotText}>●</Text> {this.convertTimeString(time)}
           </Text>
         }
@@ -169,7 +188,7 @@ export default class VideoRecorder extends Component {
             <View style={styles.content}>
               {this.renderCamera()}
             </View>
-            <TouchableOpacity onPress={this.close} style={styles.buttonClose}>
+            <TouchableOpacity onPress={this.close} style={this.props.buttonCloseStyle}>
               <Icon name="close" size={32} color={'white'} />
             </TouchableOpacity>
           </View>

--- a/lib/index.android.js
+++ b/lib/index.android.js
@@ -10,9 +10,8 @@ import {
 import PropTypes from 'prop-types'
 import moment from 'moment';
 import Camera from 'react-native-camera';
-import Icon from 'react-native-vector-icons/MaterialIcons';
 import RecordingButton from './RecordingButton';
-import styles, { buttonClose, durationText } from './style';
+import styles, { buttonClose, durationText, renderClose, renderDone } from './style';
 
 export default class VideoRecorder extends Component {
   static propTypes = {
@@ -20,6 +19,9 @@ export default class VideoRecorder extends Component {
     runAfterInteractions: PropTypes.bool,
     buttonCloseStyle: PropTypes.shape({}),
     durationTextStyle: PropTypes.shape({}),
+    maxLength: PropTypes.number,
+    renderClose: PropTypes.func,
+    renderDone: PropTypes.func,
   }
 
   static defaultProps = {
@@ -27,6 +29,9 @@ export default class VideoRecorder extends Component {
     runAfterInteractions: true,
     buttonCloseStyle: buttonClose,
     durationTextStyle: durationText,
+    maxLength: -1,
+    renderClose,
+    renderDone,
   }
 
   constructor(...props) {
@@ -89,10 +94,12 @@ export default class VideoRecorder extends Component {
         });
       });
     };
-    if (this.props.runAfterInteractions) {
-      InteractionManager.runAfterInteractions(shouldStartCapture);
-    } else {
-      shouldStartCapture();
+    if ((this.props.maxLength > 0) || (this.props.maxLength < 0)) {
+      if (this.props.runAfterInteractions) {
+        InteractionManager.runAfterInteractions(shouldStartCapture);
+      } else {
+        shouldStartCapture();
+      }
     }
   }
 
@@ -113,7 +120,11 @@ export default class VideoRecorder extends Component {
 
   startTimer = () => {
     this.timer = setInterval(() => {
-      this.setState({ time: this.state.time + 1 });
+      const time = this.state.time + 1;
+      this.setState({ time });
+      if (this.props.maxLength >= 0 && time >= this.props.maxLength) {
+        this.stopCapture();
+      }
     }, 1000);
   }
 
@@ -151,7 +162,7 @@ export default class VideoRecorder extends Component {
             recorded &&
               <TouchableOpacity onPress={this.onSave} style={styles.btnUse}>
                 <View style={styles.btnUseContainer}>
-                  <Icon style={styles.btnUseText} name="done" size={24} color="white" />
+                  {this.props.renderDone()}
                 </View>
               </TouchableOpacity>
           }
@@ -189,7 +200,7 @@ export default class VideoRecorder extends Component {
               {this.renderCamera()}
             </View>
             <TouchableOpacity onPress={this.close} style={this.props.buttonCloseStyle}>
-              <Icon name="close" size={32} color={'white'} />
+              {this.props.renderClose()}
             </TouchableOpacity>
           </View>
         </View>

--- a/lib/index.android.js
+++ b/lib/index.android.js
@@ -161,9 +161,7 @@ export default class VideoRecorder extends Component {
           {
             recorded &&
               <TouchableOpacity onPress={this.onSave} style={styles.btnUse}>
-                <View style={styles.btnUseContainer}>
-                  {this.props.renderDone()}
-                </View>
+                {this.props.renderDone()}
               </TouchableOpacity>
           }
         </View>

--- a/lib/index.android.js
+++ b/lib/index.android.js
@@ -12,7 +12,7 @@ import moment from 'moment';
 import Camera from 'react-native-camera';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import RecordingButton from './RecordingButton';
-import styles from './style';
+import styles, { buttonClose, durationText } from './style';
 
 export default class VideoRecorder extends Component {
   static propTypes = {
@@ -25,8 +25,8 @@ export default class VideoRecorder extends Component {
   static defaultProps = {
     isOpen: false,
     runAfterInteractions: true,
-    buttonCloseStyle: styles.buttonClose,
-    durationTextStyle: styles.durationText,
+    buttonCloseStyle: buttonClose,
+    durationTextStyle: durationText,
   }
 
   constructor(...props) {

--- a/lib/index.ios.js
+++ b/lib/index.ios.js
@@ -19,12 +19,20 @@ import styles from './style';
 export default class VideoRecorder extends Component {
   static propTypes = {
     isOpen: PropTypes.bool,
+    runAfterInteractions: PropTypes.bool,
     compressQuality: PropTypes.string,
+    convertingText: PropTypes.string,
+    buttonCloseStyle: PropTypes.shape({}),
+    durationTextStyle: PropTypes.shape({}),
   }
 
   static defaultProps = {
     isOpen: false,
+    runAfterInteractions: true,
     compressQuality: 'medium',
+    convertingText: 'Converting video to MP4...',
+    buttonCloseStyle: styles.buttonClose,
+    durationTextStyle: styles.durationText,
   }
 
   constructor(...props) {
@@ -40,9 +48,12 @@ export default class VideoRecorder extends Component {
   }
 
   componentDidMount() {
-    InteractionManager.runAfterInteractions(() => {
-      this.setState({ loading: false });
-    });
+    const doPostMount = () => this.setState({ loading: false });
+    if (this.props.runAfterInteractions) {
+      InteractionManager.runAfterInteractions(doPostMount);
+    } else {
+      doPostMount();
+    }
   }
 
   onSave = () => {
@@ -78,7 +89,7 @@ export default class VideoRecorder extends Component {
   }
 
   startCapture = () => {
-    InteractionManager.runAfterInteractions(() => {
+    const shouldStartCapture = () => {
       this.camera.capture()
       .then((data) => {
         console.log('video capture', data);
@@ -96,17 +107,27 @@ export default class VideoRecorder extends Component {
           time: 0,
         });
       });
-    });
+    };
+    if (this.props.runAfterInteractions) {
+      InteractionManager.runAfterInteractions(shouldStartCapture);
+    } else {
+      shouldStartCapture();
+    }
   }
 
   stopCapture = () => {
-    InteractionManager.runAfterInteractions(() => {
+    const shouldStopCapture = () => {
       this.stopTimer();
       this.camera.stopCapture();
       this.setState({
         isRecording: false,
       });
-    });
+    };
+    if (this.props.runAfterInteractions) {
+      InteractionManager.runAfterInteractions(shouldStopCapture);
+    } else {
+      shouldStopCapture();
+    }
   }
 
   startTimer = () => {
@@ -129,7 +150,7 @@ export default class VideoRecorder extends Component {
       <View>
         {
           (recorded || isRecording) &&
-          <Text style={styles.durationText}>
+          <Text style={this.props.durationTextStyle}>
             <Text style={styles.dotText}>●</Text> {this.convertTimeString(time)}
           </Text>
         }
@@ -176,7 +197,7 @@ export default class VideoRecorder extends Component {
     if (this.state.converting) {
       return (
         <Loader style={styles.backdrop}>
-          <Text style={styles.convertingText}>Converting video to MP4...</Text>
+          <Text style={styles.convertingText}>{this.props.convertingText}</Text>
         </Loader>
       );
     }
@@ -198,7 +219,7 @@ export default class VideoRecorder extends Component {
               {this.renderCamera()}
               {this.renderLoader()}
             </View>
-            <TouchableOpacity onPress={this.close} style={styles.buttonClose}>
+            <TouchableOpacity onPress={this.close} style={this.props.buttonCloseStyle}>
               <Icon name="close" size={32} color={'white'} />
             </TouchableOpacity>
           </View>

--- a/lib/index.ios.js
+++ b/lib/index.ios.js
@@ -180,9 +180,7 @@ export default class VideoRecorder extends Component {
           {
             recorded &&
               <TouchableOpacity onPress={this.onSave} style={styles.btnUse}>
-                <View style={styles.btnUseContainer}>
-                  {this.props.renderDone()}
-                </View>
+                {this.props.renderDone()}
               </TouchableOpacity>
           }
         </View>

--- a/lib/index.ios.js
+++ b/lib/index.ios.js
@@ -14,7 +14,7 @@ import Compress from 'react-native-compress';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import RecordingButton from './RecordingButton';
 import Loader from './Loader';
-import styles from './style';
+import styles, { buttonClose, durationText } from './style';
 
 export default class VideoRecorder extends Component {
   static propTypes = {
@@ -31,8 +31,8 @@ export default class VideoRecorder extends Component {
     runAfterInteractions: true,
     compressQuality: 'medium',
     convertingText: 'Converting video to MP4...',
-    buttonCloseStyle: styles.buttonClose,
-    durationTextStyle: styles.durationText,
+    buttonCloseStyle: buttonClose,
+    durationTextStyle: durationText,
   }
 
   constructor(...props) {

--- a/lib/index.ios.js
+++ b/lib/index.ios.js
@@ -11,10 +11,9 @@ import PropTypes from 'prop-types'
 import moment from 'moment';
 import Camera from 'react-native-camera';
 import Compress from 'react-native-compress';
-import Icon from 'react-native-vector-icons/MaterialIcons';
 import RecordingButton from './RecordingButton';
 import Loader from './Loader';
-import styles, { buttonClose, durationText } from './style';
+import styles, { buttonClose, durationText, renderClose, renderDone } from './style';
 
 export default class VideoRecorder extends Component {
   static propTypes = {
@@ -24,6 +23,9 @@ export default class VideoRecorder extends Component {
     convertingText: PropTypes.string,
     buttonCloseStyle: PropTypes.shape({}),
     durationTextStyle: PropTypes.shape({}),
+    maxLength: PropTypes.number,
+    renderClose: PropTypes.func,
+    renderDone: PropTypes.func,
   }
 
   static defaultProps = {
@@ -33,6 +35,9 @@ export default class VideoRecorder extends Component {
     convertingText: 'Converting video to MP4...',
     buttonCloseStyle: buttonClose,
     durationTextStyle: durationText,
+    maxLength: -1,
+    renderClose,
+    renderDone,
   }
 
   constructor(...props) {
@@ -108,10 +113,12 @@ export default class VideoRecorder extends Component {
         });
       });
     };
-    if (this.props.runAfterInteractions) {
-      InteractionManager.runAfterInteractions(shouldStartCapture);
-    } else {
-      shouldStartCapture();
+    if ((this.props.maxLength > 0) || (this.props.maxLength < 0)) {
+      if (this.props.runAfterInteractions) {
+        InteractionManager.runAfterInteractions(shouldStartCapture);
+      } else {
+        shouldStartCapture();
+      }
     }
   }
 
@@ -132,7 +139,11 @@ export default class VideoRecorder extends Component {
 
   startTimer = () => {
     this.timer = setInterval(() => {
-      this.setState({ time: this.state.time + 1 });
+      const time = this.state.time + 1;
+      this.setState({ time });
+      if (this.props.maxLength > 0 && time >= this.props.maxLength) {
+        this.stopCapture();
+      }
     }, 1000);
   }
 
@@ -170,7 +181,7 @@ export default class VideoRecorder extends Component {
             recorded &&
               <TouchableOpacity onPress={this.onSave} style={styles.btnUse}>
                 <View style={styles.btnUseContainer}>
-                  <Icon style={styles.btnUseText} name="done" size={24} color="white" />
+                  {this.props.renderDone()}
                 </View>
               </TouchableOpacity>
           }
@@ -220,7 +231,7 @@ export default class VideoRecorder extends Component {
               {this.renderLoader()}
             </View>
             <TouchableOpacity onPress={this.close} style={this.props.buttonCloseStyle}>
-              <Icon name="close" size={32} color={'white'} />
+              {this.props.renderClose()}
             </TouchableOpacity>
           </View>
         </View>

--- a/lib/style.js
+++ b/lib/style.js
@@ -2,6 +2,7 @@ import {
   StyleSheet,
   Dimensions,
   Platform,
+  View,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 
@@ -89,19 +90,6 @@ export default StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  btnUseContainer: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    borderWidth: 2,
-    borderColor: 'white',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#03C9A9',
-  },
-  btnUseText: {
-    backgroundColor: 'transparent',
-  },
   convertingText: {
     color: 'white',
     fontSize: 17,
@@ -112,4 +100,15 @@ export default StyleSheet.create({
 
 export const renderClose = () => <Icon name="close" size={32} color="white" />;
 
-export const renderDone = () => <Icon style={styles.btnUseText} name="done" size={24} color="white" />;
+export const renderDone = () => <View style={{
+  width: 40,
+  height: 40,
+  borderRadius: 20,
+  borderWidth: 2,
+  borderColor: 'white',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: '#03C9A9',
+}}><Icon style={{
+  backgroundColor: 'transparent',
+}} name="done" size={24} color="white" /></View>;

--- a/lib/style.js
+++ b/lib/style.js
@@ -5,6 +5,25 @@ import {
 } from 'react-native';
 
 const { width, height } = Dimensions.get('window');
+
+export const buttonClose = {
+  position: 'absolute',
+  right: 5,
+  top: 10,
+  width: 40,
+  height: 40,
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+export const durationText = {
+  marginTop: Platform.OS === 'ios' ? 20 : 20,
+  color: 'white',
+  textAlign: 'center',
+  fontSize: 20,
+  alignItems: 'center',
+};
+
 export default StyleSheet.create({
   modal: {
     alignItems: 'center',
@@ -30,15 +49,7 @@ export default StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  buttonClose: {
-    position: 'absolute',
-    right: 5,
-    top: 10,
-    width: 40,
-    height: 40,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
+  buttonClose,
   preview: {
     width,
     height,
@@ -62,13 +73,7 @@ export default StyleSheet.create({
   recodingButton: {
     marginBottom: Platform.OS === 'ios' ? 0 : 20,
   },
-  durationText: {
-    marginTop: Platform.OS === 'ios' ? 20 : 20,
-    color: 'white',
-    textAlign: 'center',
-    fontSize: 20,
-    alignItems: 'center',
-  },
+  durationText,
   dotText: {
     color: '#D91E18',
     fontSize: 10,

--- a/lib/style.js
+++ b/lib/style.js
@@ -3,6 +3,7 @@ import {
   Dimensions,
   Platform,
 } from 'react-native';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 
 const { width, height } = Dimensions.get('window');
 
@@ -108,3 +109,7 @@ export default StyleSheet.create({
     textAlign: 'center',
   },
 });
+
+export const renderClose = () => <Icon name="close" size={32} color="white" />;
+
+export const renderDone = () => <Icon style={styles.btnUseText} name="done" size={24} color="white" />;

--- a/lib/style.js
+++ b/lib/style.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   StyleSheet,
   Dimensions,


### PR DESCRIPTION
Hey [phouchau](https://github.com/phuochau)!

Thank you for this wicked library. This was the easiest native integration I've experienced so far, and the end result is indeed beautiful!

In this PR I've intended to make the following options:
  - Choosing to schedule an operation during `runAfterInteractions` or invoke immediately is defined by the `bool` `prop` `runAfterInteractions`. This is because in my project, none of these functions were ever scheduled to be executed. I believe this is an external [issue](https://github.com/facebook/react-naxative/issues/6643). By default, it will still intend to run as you originally defined, and is intended just as a workaround for projects in an unfortunate position as mine!
  - I've externalized some of the `style` `prop`s for the close button and the duration text. I've done this because I felt it might be useful to introduce a little more `marginTop`/`paddingTop` on iOS, but that might only be suitable for my project.

Again, thanks for open sourcing such a high quality library! 